### PR TITLE
Add github API host

### DIFF
--- a/XBotBuilder/XBotBuilder/AppDelegate.swift
+++ b/XBotBuilder/XBotBuilder/AppDelegate.swift
@@ -40,6 +40,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet weak var githubAPIToken: NSTextField!
     @IBOutlet weak var githubProjectIdentifier: NSTextField!
     @IBOutlet weak var githubServer: NSTextField!
+    @IBOutlet weak var githubApiServer: NSTextField!
 
     func applicationDidFinishLaunching(aNotification: NSNotification?) {
         self.configureModelsFromPersistence()
@@ -55,7 +56,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         var gitHubRepo = GitHubRepo(
             token: githubConfig.apiToken,
             repoName: githubConfig.projectIdentifier,
-            server: githubConfig.githubServer == "" ? nil : githubConfig.githubServer
+            server: githubConfig.githubServer == "" ? nil : githubConfig.githubServer,
+            apiServer: githubConfig.githubApiServer == "" ? nil : githubConfig.githubApiServer
         )
 
         var botServer = XBot.Server(
@@ -89,6 +91,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         self.githubAPIToken.stringValue = self.githubConfig.apiToken
         self.githubProjectIdentifier.stringValue = self.githubConfig.projectIdentifier
         self.githubServer.stringValue = self.githubConfig.githubServer
+        self.githubApiServer.stringValue = self.githubConfig.githubApiServer
         
         self.projectNameOrWorkspace.stringValue = self.projectConfig.nameOrWorkspace
         self.projectSchemeName.stringValue = self.projectConfig.schemeName
@@ -109,6 +112,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         self.githubConfig.apiToken = self.githubAPIToken.stringValue
         self.githubConfig.projectIdentifier = self.githubProjectIdentifier.stringValue
         self.githubConfig.githubServer = self.githubServer.stringValue
+        self.githubConfig.githubApiServer = self.githubApiServer.stringValue
         
         self.projectConfig.nameOrWorkspace = self.projectNameOrWorkspace.stringValue
         self.projectConfig.schemeName = self.projectSchemeName.stringValue

--- a/XBotBuilder/XBotBuilder/Base.lproj/MainMenu.xib
+++ b/XBotBuilder/XBotBuilder/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6249" systemVersion="14A388a" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1510" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6249"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6751"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -15,6 +15,7 @@
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="XBotBuilder" customModuleProvider="target">
             <connections>
                 <outlet property="githubAPIToken" destination="biY-gp-WzU" id="gxs-Ul-soY"/>
+                <outlet property="githubApiServer" destination="udH-vh-6zN" id="J62-f5-Gtr"/>
                 <outlet property="githubProjectIdentifier" destination="xaW-Fp-wJo" id="H96-8L-n0t"/>
                 <outlet property="githubServer" destination="UUq-X2-gIA" id="hvF-xM-KHm"/>
                 <outlet property="projectAnalyzeBuild" destination="9du-ZU-tzb" id="lFE-OU-Wd1"/>
@@ -685,7 +686,7 @@
         <window title="XBot Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="QvC-M9-y7g">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <rect key="contentRect" x="335" y="390" width="552" height="460"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
             <view key="contentView" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="552" height="460"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -717,12 +718,12 @@
                         <font key="font" metaFont="system"/>
                         <tabViewItems>
                             <tabViewItem label="XCode Server" identifier="1" id="9My-Fz-cpN">
-                                <view key="view" ambiguous="YES" id="AQT-pd-SyO">
-                                    <rect key="frame" x="10" y="33" width="506" height="325"/>
+                                <view key="view" id="AQT-pd-SyO">
+                                    <rect key="frame" x="10" y="33" width="201" height="0.0"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NGY-6S-CmE">
-                                            <rect key="frame" x="15" y="271" width="30" height="17"/>
+                                            <rect key="frame" x="15" y="-54" width="30" height="17"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Port" id="a0e-FC-UWV">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -730,7 +731,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField identifier="serverAddress" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hkp-Ie-mjt">
-                                            <rect key="frame" x="218" y="300" width="271" height="22"/>
+                                            <rect key="frame" x="218" y="-25" width="271" height="22"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="justified" placeholderString="10.0.1.1" drawsBackground="YES" id="1xA-jT-omi">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -741,7 +742,7 @@
                                             </connections>
                                         </textField>
                                         <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9sI-AM-6tO">
-                                            <rect key="frame" x="218" y="268" width="271" height="22"/>
+                                            <rect key="frame" x="218" y="-57" width="271" height="22"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="Ld1-pG-LLg">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -752,7 +753,7 @@
                                             </connections>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="S9J-N7-N03">
-                                            <rect key="frame" x="15" y="241" width="67" height="17"/>
+                                            <rect key="frame" x="15" y="-84" width="67" height="17"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Username" id="erF-SE-Drz">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -760,7 +761,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yi3-Ol-W47">
-                                            <rect key="frame" x="15" y="209" width="62" height="17"/>
+                                            <rect key="frame" x="15" y="-116" width="62" height="17"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Password" id="nkP-0O-uBM">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -768,7 +769,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qO5-j2-xjd">
-                                            <rect key="frame" x="218" y="238" width="271" height="22"/>
+                                            <rect key="frame" x="218" y="-87" width="271" height="22"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="ny3-Yg-1L6">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -779,7 +780,7 @@
                                             </connections>
                                         </textField>
                                         <secureTextField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="J9K-dh-iD8">
-                                            <rect key="frame" x="218" y="206" width="271" height="22"/>
+                                            <rect key="frame" x="218" y="-119" width="271" height="22"/>
                                             <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="x51-5x-E3Q">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -793,7 +794,7 @@
                                             </connections>
                                         </secureTextField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5vp-HH-JtW">
-                                            <rect key="frame" x="15" y="303" width="100" height="17"/>
+                                            <rect key="frame" x="15" y="-22" width="100" height="17"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Address" id="A1l-ud-RIj">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -984,6 +985,25 @@
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mjw-xd-QsT">
                                             <rect key="frame" x="15" y="217" width="90" height="17"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Github Server" id="Ugg-N9-Xeo">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="udH-vh-6zN">
+                                            <rect key="frame" x="218" y="176" width="271" height="22"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="https://api.github.com" drawsBackground="YES" id="J7U-Oj-DuX">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                            <connections>
+                                                <outlet property="delegate" destination="Voe-Tx-rLC" id="XRJ-he-eTC"/>
+                                            </connections>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RVj-VR-nuZ">
+                                            <rect key="frame" x="15" y="179" width="115" height="17"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Github API Server" id="AIr-ff-fiG">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>

--- a/XBotBuilder/XBotBuilder/GitHubRepo.swift
+++ b/XBotBuilder/XBotBuilder/GitHubRepo.swift
@@ -12,20 +12,29 @@ import Alamofire
 class GitHubRepo {
 
     var server: String?
+    var apiServer: String?
     var token: String
     var repoName: String
     var githubServer: String {
         if server == "" {
+            return "https://github.com"
+        }
+        
+        return server ?? "https://github.com"
+    }
+    var githubApiServer: String {
+        if apiServer == "" {
             return "https://api.github.com"
         }
         
-        return server ?? "https://api.github.com"
+        return apiServer ?? "https://api.github.com"
     }
     
-    init(token: String, repoName: String, server: String?) {
+    init(token: String, repoName: String, server: String?, apiServer: String?) {
         self.token = token
         self.repoName = repoName
         self.server = server
+        self.apiServer = apiServer
     }
     
     func fetchPullRequests(completion:([GitHubPullRequest], NSError?) -> ()) {
@@ -36,7 +45,7 @@ class GitHubRepo {
                 var pullRequests:[GitHubPullRequest] = []
                 var myError = error
                 if response?.statusCode == 404 {
-                    var errorMessage = "Unable to access repo"
+                    var errorMessage = "Unable to access repo: \(request.URLString)"
 
                     myError = NSError(domain:"GitHubXBotSyncDomain",
                         code:10001,
@@ -115,7 +124,7 @@ class GitHubRepo {
 
     //MARK: - private
     private func getGitHubRequest(method:String, url:String, bodyDictionary:AnyObject? = nil) -> NSMutableURLRequest {
-        var request = NSMutableURLRequest(URL: NSURL(string: "\(githubServer)\(url)")!)
+        var request = NSMutableURLRequest(URL: NSURL(string: "\(githubApiServer)\(url)")!)
         request.setValue("token \(self.token)", forHTTPHeaderField:"Authorization")
         request.HTTPMethod = method
         

--- a/XBotBuilder/XBotBuilder/GithubConfig.swift
+++ b/XBotBuilder/XBotBuilder/GithubConfig.swift
@@ -42,6 +42,15 @@ class GithubConfig {
         }
     }
     
+    var githubApiServer: String {
+        get {
+            return fetchFromDefaults("githubApiServer")
+        }
+        set {
+            persistToDefaults("githubApiServer", value: newValue)
+        }
+    }
+    
     func namespacedKey(key:String) -> String{
         var id = 1
         return "github/\(id)/\(key)"


### PR DESCRIPTION
PR comments need to be posted to `github.com` while pull requests are located via an api call to `api.github.com`. Previously all requests were made to `github.com` which would fail to obtain open PRs.

Perhaps github used to serve both from the same domain or this works in enterprise github deploys.

There might be a cleaner way to model all of these github urls so that two inputs are not needed but this seemed like a reasonable quick fix that got my builds running.
